### PR TITLE
Pass integer parameters to sd_bus_message_append correctly

### DIFF
--- a/notify.c
+++ b/notify.c
@@ -23,17 +23,15 @@ void notify(sd_bus* bus, const char* summary, const char* body)
     }
     // Fill out the parameters according to
     // https://developer.gnome.org/notification-spec/#command-notify
-    uint32_t u = 0;
-    int32_t i = -1;
     ret = sd_bus_message_append(m, "susssasa{sv}i",
         "system-notify", // STRING app_name
-        &u, // UINT32 replaces_id
+        0, // UINT32 replaces_id
         "utilities-system-monitor", // STRING app_icon
         summary, // STRING summary
         body, // STRING body
         0, // ARRAY actions
         0, // DICT hints
-        &i // INT32 expire_timeout
+        -1 // INT32 expire_timeout
     );
     if (ret < 0) {
         fprintf(stderr, "sd_bus_message_append: %s\n", strerror(-ret));


### PR DESCRIPTION
As the examples on https://www.freedesktop.org/software/systemd/man/sd_bus_message_append.html#Examples show, simple integral types have to be passed by value, not by address.
This mistake caused the notifications to never expire and disappear - although it was most likely undeterministic.